### PR TITLE
fix: update Docker configuration to use entrypoint script and expose port 5173

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,8 +53,17 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # Copy nginx configuration
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
-# Expose port 8080 (non-privileged port)
-EXPOSE 8080
+# Copy entrypoint script
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+USER root
+RUN chmod +x /docker-entrypoint.sh
+USER nginx
 
-# Start nginx
-CMD ["nginx", "-g", "daemon off;"]
+# Expose port 5173 (can be overridden with NGINX_PORT env var)
+EXPOSE 5173
+
+# Set default port
+ENV NGINX_PORT=5173
+
+# Start nginx with entrypoint script
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+# Use NGINX_PORT environment variable or default to 5173
+PORT=${NGINX_PORT:-5173}
+
+echo "Starting nginx on port $PORT"
+
+# Replace the port in nginx configuration
+sed -i "s/listen [0-9]\+;/listen $PORT;/g" /etc/nginx/conf.d/default.conf
+
+# Execute the original nginx command
+exec nginx -g "daemon off;"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 8080;
+    listen 5173;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
…port 5173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default container port to 5173
  * Made port configurable through environment variable
  * Refactored container startup process

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->