### PR TITLE
Update & create server pics

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -34,7 +34,12 @@
       "public": "Public",
       "private": "Private",
       "cancel": "Cancel",
-      "create": "Create server"
+      "create": "Create server",
+      "save": "Save",
+      "picture_upload": "Upload Server Picture",
+      "banner_upload": "Upload Server Banner",
+      "click_to_upload": "Click to upload",
+      "click_to_upload_banner": "Click to upload banner"
     }
   },
   "userNav": {
@@ -361,6 +366,18 @@
     "updateName": {
       "success": "Server name updated successfully",
       "error": "Failed to update server name"
+    },
+    "updateBanner": {
+      "title": "Update Server Banner",
+      "save": "Save",
+      "success": "Server banner updated successfully",
+      "error": "Failed to update server banner"
+    },
+    "updatePicture": {
+      "title": "Update Server Picture",
+      "save": "Save",
+      "success": "Server picture updated successfully",
+      "error": "Failed to update server picture"
     }
   }
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -34,7 +34,12 @@
       "public": "Public",
       "private": "Privé",
       "cancel": "Annuler",
-      "create": "Créer le serveur"
+      "create": "Créer le serveur",
+      "save": "Enregistrer",
+      "picture_upload": "Télécharger l'image du serveur",
+      "banner_upload": "Télécharger la bannière du serveur",
+      "click_to_upload": "Cliquez pour télécharger",
+      "click_to_upload_banner": "Cliquez pour télécharger la bannière"
     }
   },
   "userNav": {
@@ -360,6 +365,18 @@
     "updateName": {
       "success": "Nom du serveur mis à jour avec succès",
       "error": "Échec de la mise à jour du nom du serveur"
+    },
+    "updateBanner": {
+      "title": "Modifier la bannière du serveur",
+      "save": "Enregistrer",
+      "success": "Bannière du serveur mise à jour avec succès",
+      "error": "Échec de la mise à jour de la bannière du serveur"
+    },
+    "updatePicture": {
+      "title": "Modifier l'image du serveur",
+      "save": "Enregistrer",
+      "success": "Image du serveur mise à jour avec succès",
+      "error": "Échec de la mise à jour de l'image du serveur"
     }
   }
 }

--- a/src/pages/server-settings/feature/PageServerProfileSettingsFeature.tsx
+++ b/src/pages/server-settings/feature/PageServerProfileSettingsFeature.tsx
@@ -16,6 +16,17 @@ export function PageServerProfileSettingsFeature({
   const { data, isError, isSuccess, isLoading } = useServerById(serverId)
   const updateServerMutation = useUpdateServer(serverId)
   const [isDescriptionDialogOpen, setIsDescriptionDialogOpen] = useState(false)
+  const [isBannerDialogOpen, setIsBannerDialogOpen] = useState(false)
+  const [isPictureDialogOpen, setIsPictureDialogOpen] = useState(false)
+
+  const blobToDataUrl = (blob: Blob): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onloadend = () => resolve(reader.result as string)
+      reader.onerror = reject
+      reader.readAsDataURL(blob)
+    })
+  }
 
   const handleNameChange = async (_server: Server, newName: string) => {
     if (!newName.trim()) {
@@ -51,6 +62,36 @@ export function PageServerProfileSettingsFeature({
     }
   }
 
+  const handleBannerClick = () => {
+    setIsBannerDialogOpen(true)
+  }
+
+  const handleBannerSave = async (blob: Blob) => {
+    try {
+      const dataUrl = await blobToDataUrl(blob)
+      await updateServerMutation.mutateAsync({ banner_url: dataUrl })
+      toast.success(t("serverSettings.updateBanner.success"))
+    } catch (error) {
+      console.error("Error updating server banner:", error)
+      toast.error(t("serverSettings.updateBanner.error"))
+    }
+  }
+
+  const handlePictureClick = () => {
+    setIsPictureDialogOpen(true)
+  }
+
+  const handlePictureSave = async (blob: Blob) => {
+    try {
+      const dataUrl = await blobToDataUrl(blob)
+      await updateServerMutation.mutateAsync({ picture_url: dataUrl })
+      toast.success(t("serverSettings.updatePicture.success"))
+    } catch (error) {
+      console.error("Error updating server picture:", error)
+      toast.error(t("serverSettings.updatePicture.error"))
+    }
+  }
+
   return (
     <PageServerProfileSettings
       server={data}
@@ -62,6 +103,14 @@ export function PageServerProfileSettingsFeature({
       onDescriptionSave={handleDescriptionSave}
       isDescriptionDialogOpen={isDescriptionDialogOpen}
       setIsDescriptionDialogOpen={setIsDescriptionDialogOpen}
+      onBannerClick={handleBannerClick}
+      onBannerSave={handleBannerSave}
+      isBannerDialogOpen={isBannerDialogOpen}
+      setIsBannerDialogOpen={setIsBannerDialogOpen}
+      onPictureClick={handlePictureClick}
+      onPictureSave={handlePictureSave}
+      isPictureDialogOpen={isPictureDialogOpen}
+      setIsPictureDialogOpen={setIsPictureDialogOpen}
     />
   )
 }

--- a/src/pages/server-settings/ui/PageServerProfileSettings.tsx
+++ b/src/pages/server-settings/ui/PageServerProfileSettings.tsx
@@ -2,6 +2,8 @@ import ServerCard from "@/shared/components/ServerCard"
 import { Skeleton } from "@/shared/components/ui/Skeleton"
 import type { Server } from "@/shared/queries/community/community.types"
 import UpdateDescriptionDialog from "./UpdateDescriptionDialog"
+import UpdateBannerDialog from "./UpdateBannerDialog"
+import UpdatePictureDialog from "./UpdatePictureDialog"
 import type { Dispatch, SetStateAction } from "react"
 
 interface PageServerProfileSettingsProps {
@@ -14,6 +16,14 @@ interface PageServerProfileSettingsProps {
   onDescriptionSave: (description: string) => void
   isDescriptionDialogOpen: boolean
   setIsDescriptionDialogOpen: Dispatch<SetStateAction<boolean>>
+  onBannerClick: () => void
+  onBannerSave: (blob: Blob) => void
+  isBannerDialogOpen: boolean
+  setIsBannerDialogOpen: Dispatch<SetStateAction<boolean>>
+  onPictureClick: () => void
+  onPictureSave: (blob: Blob) => void
+  isPictureDialogOpen: boolean
+  setIsPictureDialogOpen: Dispatch<SetStateAction<boolean>>
 }
 export function PageServerProfileSettings({
   server,
@@ -24,6 +34,14 @@ export function PageServerProfileSettings({
   onDescriptionSave,
   isDescriptionDialogOpen,
   setIsDescriptionDialogOpen,
+  onBannerClick,
+  onBannerSave,
+  isBannerDialogOpen,
+  setIsBannerDialogOpen,
+  onPictureClick,
+  onPictureSave,
+  isPictureDialogOpen,
+  setIsPictureDialogOpen,
 }: PageServerProfileSettingsProps) {
   return (
     <div className="flex w-full justify-center">
@@ -35,6 +53,8 @@ export function PageServerProfileSettings({
               server={server}
               onNameChange={onNameChange}
               onDescriptionClick={onDescriptionClick}
+              onBannerClick={onBannerClick}
+              onPictureClick={onPictureClick}
               descriptionSize="large"
             />
           </div>
@@ -43,6 +63,16 @@ export function PageServerProfileSettings({
             onOpenChange={setIsDescriptionDialogOpen}
             server={server}
             onSave={onDescriptionSave}
+          />
+          <UpdateBannerDialog
+            isOpen={isBannerDialogOpen}
+            onOpenChange={setIsBannerDialogOpen}
+            onSave={onBannerSave}
+          />
+          <UpdatePictureDialog
+            isOpen={isPictureDialogOpen}
+            onOpenChange={setIsPictureDialogOpen}
+            onSave={onPictureSave}
           />
         </>
       )}

--- a/src/pages/server-settings/ui/UpdateBannerDialog.tsx
+++ b/src/pages/server-settings/ui/UpdateBannerDialog.tsx
@@ -1,0 +1,72 @@
+import { Button } from "@/shared/components/ui/Button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/shared/components/ui/Dialog"
+import { useTranslation } from "react-i18next"
+import { PictureForm, PicturePreview, usePictureForm } from "@/shared/components/PictureForm"
+
+interface UpdateBannerDialogProps {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  onSave: (blob: Blob) => void
+}
+
+function UpdateBannerDialogContent({
+  onSave,
+  onClose,
+}: {
+  onSave: (blob: Blob) => void
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  const { handleSubmit, compressedImage } = usePictureForm()
+
+  const onSubmit = handleSubmit(() => {
+    if (compressedImage) {
+      onSave(compressedImage)
+      onClose()
+    }
+  })
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{t("serverSettings.updateBanner.title")}</DialogTitle>
+      </DialogHeader>
+      <div className="flex flex-col gap-4 py-4">
+        <PicturePreview className="h-60 w-full" boxClassName="w-full h-60" />
+      </div>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant="outline">{t("common.cancel")}</Button>
+        </DialogClose>
+        <Button onClick={onSubmit} disabled={!compressedImage}>
+          {t("serverSettings.updateBanner.save")}
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}
+
+export default function UpdateBannerDialog({
+  isOpen,
+  onOpenChange,
+  onSave,
+}: UpdateBannerDialogProps) {
+  const handleClose = () => onOpenChange(false)
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <PictureForm compressionOptions={{ maxWidth: 1200, maxHeight: 400, quality: 0.9 }}>
+          <UpdateBannerDialogContent onSave={onSave} onClose={handleClose} />
+        </PictureForm>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/pages/server-settings/ui/UpdatePictureDialog.tsx
+++ b/src/pages/server-settings/ui/UpdatePictureDialog.tsx
@@ -1,0 +1,72 @@
+import { Button } from "@/shared/components/ui/Button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/shared/components/ui/Dialog"
+import { useTranslation } from "react-i18next"
+import { PictureForm, PicturePreview, usePictureForm } from "@/shared/components/PictureForm"
+
+interface UpdatePictureDialogProps {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  onSave: (blob: Blob) => void
+}
+
+function UpdatePictureDialogContent({
+  onSave,
+  onClose,
+}: {
+  onSave: (blob: Blob) => void
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  const { handleSubmit, compressedImage } = usePictureForm()
+
+  const onSubmit = handleSubmit(() => {
+    if (compressedImage) {
+      onSave(compressedImage)
+      onClose()
+    }
+  })
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{t("serverSettings.updatePicture.title")}</DialogTitle>
+      </DialogHeader>
+      <div className="flex flex-col gap-4 py-4">
+        <PicturePreview className="mx-auto h-60 w-60" boxClassName="w-60 h-60" />
+      </div>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant="outline">{t("common.cancel")}</Button>
+        </DialogClose>
+        <Button onClick={onSubmit} disabled={!compressedImage}>
+          {t("serverSettings.updatePicture.save")}
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}
+
+export default function UpdatePictureDialog({
+  isOpen,
+  onOpenChange,
+  onSave,
+}: UpdatePictureDialogProps) {
+  const handleClose = () => onOpenChange(false)
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <PictureForm compressionOptions={{ maxWidth: 800, maxHeight: 800, quality: 0.9 }}>
+          <UpdatePictureDialogContent onSave={onSave} onClose={handleClose} />
+        </PictureForm>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/shared/components/ServerBannerDialog.tsx
+++ b/src/shared/components/ServerBannerDialog.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react"
+import { Button } from "@/shared/components/ui/Button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/shared/components/ui/Dialog"
+import { useTranslation } from "react-i18next"
+import { PictureForm, PicturePreview, usePictureForm } from "@/shared/components/PictureForm"
+import { ImagePlus } from "lucide-react"
+import { cn } from "@/shared/lib/utils"
+
+interface ServerBannerDialogProps {
+  value?: string
+  onChange: (value: string) => void
+  className?: string
+}
+
+function BannerDialogContent({
+  onSave,
+  onClose,
+}: {
+  onSave: (dataUrl: string) => void
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  const { handleSubmit, compressedImage } = usePictureForm()
+
+  const blobToDataUrl = (blob: Blob): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onloadend = () => resolve(reader.result as string)
+      reader.onerror = reject
+      reader.readAsDataURL(blob)
+    })
+  }
+
+  const onSubmit = handleSubmit(async () => {
+    if (compressedImage) {
+      const dataUrl = await blobToDataUrl(compressedImage)
+      onSave(dataUrl)
+      onClose()
+    }
+  })
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{t("serverNav.modal.banner_upload")}</DialogTitle>
+      </DialogHeader>
+      <div className="flex flex-col gap-4 py-4">
+        <PicturePreview className="h-60 w-full" boxClassName="w-full h-60" />
+      </div>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant="outline">{t("common.cancel")}</Button>
+        </DialogClose>
+        <Button onClick={onSubmit} disabled={!compressedImage}>
+          {t("serverNav.modal.save")}
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}
+
+export default function ServerBannerDialog({
+  value,
+  onChange,
+  className,
+}: ServerBannerDialogProps) {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleSave = (dataUrl: string) => {
+    onChange(dataUrl)
+    setIsOpen(false)
+  }
+
+  return (
+    <>
+      <div
+        onClick={() => setIsOpen(true)}
+        className={cn(
+          "bg-muted relative h-32 w-full cursor-pointer overflow-hidden rounded-lg",
+          "border-border hover:border-primary border-2 border-dashed transition-colors",
+          "group flex items-center justify-center",
+          className
+        )}
+      >
+        {value ? (
+          <>
+            <img src={value} alt="Banner preview" className="h-full w-full object-cover" />
+            <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
+              <ImagePlus className="h-8 w-8 text-white" />
+            </div>
+          </>
+        ) : (
+          <div className="text-muted-foreground flex flex-col items-center gap-2">
+            <ImagePlus className="h-8 w-8" />
+            <span className="text-sm">{t("serverNav.modal.click_to_upload_banner")}</span>
+          </div>
+        )}
+      </div>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent>
+          <PictureForm compressionOptions={{ maxWidth: 1200, maxHeight: 400, quality: 0.9 }}>
+            <BannerDialogContent onSave={handleSave} onClose={() => setIsOpen(false)} />
+          </PictureForm>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/shared/components/ServerPictureDialog.tsx
+++ b/src/shared/components/ServerPictureDialog.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react"
+import { Button } from "@/shared/components/ui/Button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "@/shared/components/ui/Dialog"
+import { useTranslation } from "react-i18next"
+import { PictureForm, PicturePreview, usePictureForm } from "@/shared/components/PictureForm"
+import { Avatar, AvatarFallback, AvatarImage } from "@/shared/components/ui/Avatar"
+import { ImagePlus } from "lucide-react"
+import { cn } from "@/shared/lib/utils"
+
+interface ServerPictureDialogProps {
+  value?: string
+  onChange: (value: string) => void
+  className?: string
+}
+
+function PictureDialogContent({
+  onSave,
+  onClose,
+}: {
+  onSave: (dataUrl: string) => void
+  onClose: () => void
+}) {
+  const { t } = useTranslation()
+  const { handleSubmit, compressedImage } = usePictureForm()
+
+  const blobToDataUrl = (blob: Blob): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onloadend = () => resolve(reader.result as string)
+      reader.onerror = reject
+      reader.readAsDataURL(blob)
+    })
+  }
+
+  const onSubmit = handleSubmit(async () => {
+    if (compressedImage) {
+      const dataUrl = await blobToDataUrl(compressedImage)
+      onSave(dataUrl)
+      onClose()
+    }
+  })
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>{t("serverNav.modal.picture_upload")}</DialogTitle>
+      </DialogHeader>
+      <div className="flex flex-col gap-4 py-4">
+        <PicturePreview className="mx-auto h-60 w-60" boxClassName="w-60 h-60" />
+      </div>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button variant="outline">{t("common.cancel")}</Button>
+        </DialogClose>
+        <Button onClick={onSubmit} disabled={!compressedImage}>
+          {t("serverNav.modal.save")}
+        </Button>
+      </DialogFooter>
+    </>
+  )
+}
+
+export default function ServerPictureDialog({
+  value,
+  onChange,
+  className,
+}: ServerPictureDialogProps) {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleSave = (dataUrl: string) => {
+    onChange(dataUrl)
+    setIsOpen(false)
+  }
+
+  return (
+    <>
+      <div
+        onClick={() => setIsOpen(true)}
+        className={cn(
+          "group relative h-24 w-24 cursor-pointer overflow-hidden rounded-lg",
+          className
+        )}
+      >
+        {value ? (
+          <>
+            <Avatar className="h-full w-full rounded-lg">
+              <AvatarImage src={value} alt="Picture preview" />
+              <AvatarFallback className="bg-primary text-primary-foreground rounded-lg">
+                <ImagePlus className="h-8 w-8" />
+              </AvatarFallback>
+            </Avatar>
+            <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
+              <ImagePlus className="h-6 w-6 text-white" />
+            </div>
+          </>
+        ) : (
+          <div className="bg-muted border-border hover:border-primary flex h-full w-full flex-col items-center justify-center gap-1 rounded-lg border-2 border-dashed transition-colors">
+            <ImagePlus className="text-muted-foreground h-6 w-6" />
+            <span className="text-muted-foreground px-1 text-center text-xs">
+              {t("serverNav.modal.click_to_upload")}
+            </span>
+          </div>
+        )}
+      </div>
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent>
+          <PictureForm compressionOptions={{ maxWidth: 800, maxHeight: 800, quality: 0.9 }}>
+            <PictureDialogContent onSave={handleSave} onClose={() => setIsOpen(false)} />
+          </PictureForm>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/shared/forms/AddServer.tsx
+++ b/src/shared/forms/AddServer.tsx
@@ -14,6 +14,8 @@ import { DialogClose, DialogFooter } from "../components/ui/Dialog"
 import { Button } from "../components/ui/Button"
 import { Switch } from "../components/ui/Switch"
 import { useTranslation } from "react-i18next"
+import ServerPictureDialog from "../components/ServerPictureDialog"
+import ServerBannerDialog from "../components/ServerBannerDialog"
 
 interface AddServerFormProps {
   form: UseFormReturn<z.infer<typeof addServerFormSchema>>
@@ -61,7 +63,7 @@ export function AddServerForm({ form, loading, onSubmit }: AddServerFormProps) {
               <FormItem className="w-full">
                 <FormLabel>{t("serverNav.modal.image_url")}</FormLabel>
                 <FormControl>
-                  <Input type="text" id="picture_url" {...field} />
+                  <ServerPictureDialog value={field.value} onChange={field.onChange} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -74,7 +76,7 @@ export function AddServerForm({ form, loading, onSubmit }: AddServerFormProps) {
               <FormItem className="w-full">
                 <FormLabel>{t("serverNav.modal.banner_url")}</FormLabel>
                 <FormControl>
-                  <Input type="text" id="banner_url" {...field} />
+                  <ServerBannerDialog value={field.value} onChange={field.onChange} />
                 </FormControl>
                 <FormMessage />
               </FormItem>


### PR DESCRIPTION
Add the ability to the user to update and create the server picture and banner.

## Added components

Import banner:

<img width="534" height="400" alt="image" src="https://github.com/user-attachments/assets/7d4e61ff-2b3c-4cf8-9fb8-d256f0bc1a07" />

Import picture:

<img width="534" height="400" alt="image" src="https://github.com/user-attachments/assets/610fa4b8-c76f-4f4d-b042-90b56db31213" />

## Create server pics

Open the modal to create server by clicking on this button:

<img width="455" height="349" alt="image" src="https://github.com/user-attachments/assets/6e03438d-1ac1-4647-b7bb-a6ad97fdeda9" />

You'll be able to select file from your pc to set the banner and picture.

<img width="548" height="657" alt="image" src="https://github.com/user-attachments/assets/c2224fc2-68ae-40a1-9373-218400fce28f" />

## Update servers pics

You can go in the server settings to update the profile of the server on this path in the application `/servers/:serverId/settings/profile` 

Then you can respectively click on the picture and banner of the server to update them.

<img width="1613" height="378" alt="image" src="https://github.com/user-attachments/assets/495fdfda-9c94-4b6d-8d93-362c51722ece" />



